### PR TITLE
Fixed sublime-command

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,11 @@
 [
     {
-        "caption": "pomodoro",
-        "command": "pomodoro"
+        "caption": "Pomodoro: Run Pomodoro",
+        "command": "pomodoro",
+        "args":
+     			{
+        			"workingMins": 30,
+    				"restingMins": 5
+    			}
     }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,7 +4,7 @@
         "command": "pomodoro",
         "args":
      			{
-        			"workingMins": 30,
+        			"workingMins": 25,
     				"restingMins": 5
     			}
     }

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This is a sublime plugin which implements functions like pomodoro.
 Usage: 
 -----------------------------
 Add the line below to your **"Preferences: Key Bindings - User"** settings:  
-{ "keys": ["ctrl+shift+p"], "command": "pomodoro", "args": {"workingMins": 25, "restingMins": 5} }
+{ "keys": ["ctrl+shift+alt+p"], "command": "pomodoro", "args": {"workingMins": 25, "restingMins": 5} }
 
 Here are two arguments need to set  
 *workingMins*: set your working time in minutes.  
 *restingMins*: set your rest time in minutes.
 
-You can stop pomodoro by pressing the binding key(e.g. "ctrl+shift+p") again, and resume it by pressing it again one more time.:smiley:
+You can stop pomodoro by pressing the binding key(e.g. "ctrl+shift+alt+p") again, and resume it by pressing it again one more time.:smiley:
 
 Preview:
 -----------------------------


### PR DESCRIPTION
1. You forgot add args in `Default.sublime-commands` file.
2. <kbd>Ctrl+Shift+P</kbd> is very bad hotkey for Pomodoro, because this hotkey used for command palette running.

Thanks.